### PR TITLE
Fixing some memory bugs

### DIFF
--- a/helper_funcs_to_excute.c
+++ b/helper_funcs_to_excute.c
@@ -41,7 +41,7 @@ char *get_av_with_flags_helper(char *token, int status)
 char **get_av_with_flags(char *line, int status)
 {
 	char *line_cpy, *token, **av, *var, *cmd;
-	int i = 0, c_count;
+	int i = 0, j, c_count;
 
 	handle_comments(line);
 	if (line[0] == '\0')
@@ -49,10 +49,19 @@ char **get_av_with_flags(char *line, int status)
 	line_cpy = _strdup(line);
 	if (line_cpy == NULL)
 		return (NULL); /*can't cpy*/
-	c_count = char_count(line_cpy, ' ');
 	
+	token = TOK_D;
+	c_count = char_count(line_cpy, ' ');
+	for ( ; i < (int) strlen(line_cpy); i++ ) 
+		for ( j = 0; j < (int) strlen(token); j++ )
+			if ( line_cpy[i] == token[j] ) {
+				c_count++;
+				break;
+			}
+			
+	i ^= i;
 	token = _strtok(line_cpy, TOK_D);
-
+	
 	cmd = get_av_with_flags_helper(token, status);
 	if ( !cmd )
 		return NULL;

--- a/helper_funcs_to_excute.c
+++ b/helper_funcs_to_excute.c
@@ -4,23 +4,17 @@
 /**
  * get_av_with_flags_helper - .
  * @token: .
- * @line: .
- * @av: .
  * @status: .
  * Return: .
 */
 
-char *get_av_with_flags_helper(char *token, char *line, char **av, int status)
+char *get_av_with_flags_helper(char *token, int status)
 {
-		char *var, *cmd, *line_cpy;
+	char *var, *cmd;
 
-	line_cpy = line;
-		if (token == NULL)
-	{
-		free(av);
-		free(line_cpy);
-		return (NULL);
-	}
+	if ( !token )
+		return NULL;
+
 	if (_strcmp("$$", token) == 0)
 		cmd = get_process_id();
 	else if (_strcmp("$?", token) == 0)
@@ -56,10 +50,19 @@ char **get_av_with_flags(char *line, int status)
 	if (line_cpy == NULL)
 		return (NULL); /*can't cpy*/
 	c_count = char_count(line_cpy, ' ');
-	av = malloc((c_count + 1) * sizeof(char *));
+	
 	token = _strtok(line_cpy, TOK_D);
 
-	cmd = get_av_with_flags_helper(token, line, av, status);
+	cmd = get_av_with_flags_helper(token, status);
+	if ( !cmd )
+		return NULL;
+
+	av = malloc((c_count + 1) * sizeof(char *));
+	if ( !av ) {
+		free( cmd );
+		return NULL;
+	}
+
 	av[i++] = cmd;
 	while (token != NULL)
 	{


### PR DESCRIPTION
Hi Kholoud,
hope you are doing well

I came across your fantastic project in my free time and got interested in reading the code. While I was reading the code, I found several bugs related to memory management, so I decided to fix them myself.

I compiled the code as follows:
```
gcc -Wall -Werror -Wextra -pedantic -std=gnu89 *.c -o KholoudShell
```

The first one was "Null Pointer Dereference":
```
┌──(user㉿host)-[~/testdir/simple_shell]
└─$ ./KholoudShell                                                             
^_* -> "
zsh: segmentation fault  ./KholoudShell
```

The bug can be triggered as shown above; this is specifically caused by improper error handling, while the `get_av_with_flags_helper` function correctly returns NULL if the token was `NULL`, but its caller (`get_av_with_flags`) doesn't check the returned value.

Another issue with this function is that it deallocates the line pointer, while the `main` function deallocates it again. The same thing happens with the av pointer. 

The second one was a Heap-based buffer overrun. The bug can be triggered as follows:

```
┌──(user㉿host)-[~/testdir/simple_shell]
└─$ ./KholoudShell                                                     
^_* -> damn?"damn       ?"damn
double free or corruption (out)
zsh: IOT instruction  ./KholoudShell
                                    
```

So I started in analysis; the bug gets triggered when the line vector gets deallocated.
![Screenshot 2025-04-07 050130](https://github.com/user-attachments/assets/61bc6dde-2ec1-4c01-91bc-1a009a66eff5)

The error message says that a double free has occurred, so I have tried to find where exactly that happens. But I found nothing; there was no double free, the error message fooled me. The bug was more complicated than that.

So at that point, I decided to track this heap chunk via Hardware breakpoints. I found that the bug occurs for a reason far away from the error message. There was a heap-based OOB write bug at the `get_av_with_flags` function that corrupted the headers of that chunk and made it appear like a freed object.

Also, I think there is a logical bug in this function (`get_av_with_flags`); it tokenizes the string without caring about the fields between single/double quotes (I haven't fixed this)

Thank you Kholoud for this amazing project,
Keep up the great work.